### PR TITLE
Turn off echoing commands for the kubectl run command

### DIFF
--- a/tasks/kubectl-run-performance-tests.yml
+++ b/tasks/kubectl-run-performance-tests.yml
@@ -30,6 +30,7 @@ run:
       # Create an performance tests pod and run the performance tests in it
       # Env vars have to passed one by one as a --env flag each
       # The sleep is to give kubectl time to attach properly, otherwise the first few log lines are lost
+      set +x
       kubectl run performance-tests -it --command --rm --quiet \
       --generator=run-pod/v1 \
       --image=${PERFORMANCE_TESTS_IMAGE} \


### PR DESCRIPTION
# Motivation and Context
We don't want to echo the command which fetches the test config.

# What has changed
* Turn off set x for the kubectl run command

# Links
https://trello.com/c/URTcwsvH/442-dont-echo-config-in-test-task-scripts