### PR TITLE
Change to JSON for metrics

### DIFF
--- a/features/steps/print_steps.py
+++ b/features/steps/print_steps.py
@@ -21,10 +21,11 @@ def wait_for_print_files(context):
                 context.produced_print_file_time = datetime.utcnow()
                 context.print_file_production_run_time = context.produced_print_file_time \
                     - context.action_rule_trigger_time
-                print(json.dumps({
+                time_taken_metric = json.dumps({
                     'event': 'Time from action rule trigger to all print files produced',
                     'time_in_seconds': str(context.print_file_production_run_time.total_seconds())
-                }) + "\n")
+                })
+                print(f'{time_taken_metric}\n')
                 break
         sleep(int(Config.SFTP_POLLING_DELAY))
 

--- a/features/steps/print_steps.py
+++ b/features/steps/print_steps.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 from pathlib import Path
 from time import sleep
@@ -20,9 +21,10 @@ def wait_for_print_files(context):
                 context.produced_print_file_time = datetime.utcnow()
                 context.print_file_production_run_time = context.produced_print_file_time \
                     - context.action_rule_trigger_time
-                # TODO nicer way to print within behave
-                print(f'Time from action rule trigger to all print files produced: '
-                      f'[{str(context.print_file_production_run_time)}]\n')
+                print(json.dumps({
+                    'event': 'Time from action rule trigger to all print files produced',
+                    'time_in_seconds': str(context.print_file_production_run_time.total_seconds())
+                }) + "\n")
                 break
         sleep(int(Config.SFTP_POLLING_DELAY))
 

--- a/features/steps/print_steps.py
+++ b/features/steps/print_steps.py
@@ -22,7 +22,8 @@ def wait_for_print_files(context):
                 context.print_file_production_run_time = context.produced_print_file_time \
                     - context.action_rule_trigger_time
                 time_taken_metric = json.dumps({
-                    'event': 'Time from action rule trigger to all print files produced',
+                    'event_description': 'Time from action rule trigger to all print files produced',
+                    'event_type': 'ACTION_RULE_TO_PRINT',
                     'time_in_seconds': str(context.print_file_production_run_time.total_seconds())
                 })
                 print(f'{time_taken_metric}\n')

--- a/features/steps/sample_steps.py
+++ b/features/steps/sample_steps.py
@@ -31,10 +31,11 @@ def wait_for_full_sample_ingest(context):
     _wait_for_queue_to_be_drained(Config.RABBITMQ_SAMPLE_TO_ACTION_QUEUE)
     context.sample_fully_ingested_time = datetime.utcnow()
     time_taken = context.sample_fully_ingested_time - context.sample_load_start_time
-    print(json.dumps({
+    time_taken_metric = json.dumps({
         'event': 'Time to fully ingest sample into action scheduler',
         'time_in_seconds': str(time_taken.total_seconds())
-    }) + '\n')
+    })
+    print(f'{time_taken_metric}\n')
 
 
 def _wait_for_queue_to_be_drained(queue_name):

--- a/features/steps/sample_steps.py
+++ b/features/steps/sample_steps.py
@@ -1,3 +1,4 @@
+import json
 import time
 from datetime import datetime
 from pathlib import Path
@@ -29,8 +30,11 @@ def wait_for_full_sample_ingest(context):
     _wait_for_queue_to_be_drained(Config.RABBITMQ_SAMPLE_INBOUND_QUEUE)
     _wait_for_queue_to_be_drained(Config.RABBITMQ_SAMPLE_TO_ACTION_QUEUE)
     context.sample_fully_ingested_time = datetime.utcnow()
-    print(f'Time to fully ingest sample into action scheduler: '
-          f'[{str(context.sample_fully_ingested_time - context.sample_load_start_time)}]\n')
+    time_taken = context.sample_fully_ingested_time - context.sample_load_start_time
+    print(json.dumps({
+        'event': 'Time to fully ingest sample into action scheduler',
+        'time_in_seconds': str(time_taken.total_seconds())
+    }) + '\n')
 
 
 def _wait_for_queue_to_be_drained(queue_name):

--- a/features/steps/sample_steps.py
+++ b/features/steps/sample_steps.py
@@ -32,7 +32,8 @@ def wait_for_full_sample_ingest(context):
     context.sample_fully_ingested_time = datetime.utcnow()
     time_taken = context.sample_fully_ingested_time - context.sample_load_start_time
     time_taken_metric = json.dumps({
-        'event': 'Time to fully ingest sample into action scheduler',
+        'event_description': 'Time to fully ingest sample into action scheduler',
+        'event_type': 'SAMPLE_INGEST_TO_ACTION_CASES',
         'time_in_seconds': str(time_taken.total_seconds())
     })
     print(f'{time_taken_metric}\n')


### PR DESCRIPTION
We need to capture metrics in GCP to monitor trends from our performance tests. This PR dumps out timings in JSON format so we can create metrics more easily. 

The two metrics can be seen in census-rm-braceh11 with the names:
`user/Event-Type`
These can be seen charted on the census-rm-braceh11 stackdriver dashboard `test dashboard`.