### PR TITLE
Making Dockerfile Use Non-root User

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM python:3.7-slim
 
-WORKDIR /app
-COPY . /app
+RUN pip install pipenv
 
-RUN apt-get update -y && apt-get install -y python-pip curl git
-RUN pip install pipenv && pipenv install --deploy --system
+RUN apt-get update -y && apt-get install -y python-pip curl git && groupadd --gid 1000 performancetests && \
+    useradd --create-home --system --uid 1000 --gid performancetests performancetests
+WORKDIR /home/performancetests
 
+COPY Pipfile* /home/performancetests/
+RUN pipenv install --deploy --system
+USER performancetests
+
+COPY --chown=performancetests . /home/performancetests


### PR DESCRIPTION
# Motivation and Context
Changing the Dockerfile to use non-root user rather than root which makes it more secure (someone could gain root access to the Docker host by hacking the application running inside the container)

# What has changed
Created new user in Dockerfile and assigned permission levels. Also optimised the order in which the image is built

# How to test? 
Clone and run performance test locally and in GCP (probably best to avoid running the second test due to the time it takes)

# Links
https://trello.com/c/Pd48zUsd