### PR TITLE
Clear down all queues after test run

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -26,6 +26,10 @@ def before_scenario(context, scenario):
     _clear_down_all_queues()
 
 
+def after_all(_):
+    _clear_down_all_queues()
+
+
 def get_msg_count(queue_name):
     uri = f'http://{Config.RABBITMQ_HOST}:{Config.RABBITMQ_MAN_PORT}/api/queues/%2f/{queue_name}'
     response = requests.get(uri, auth=(Config.RABBITMQ_USER, Config.RABBITMQ_PASSWORD))


### PR DESCRIPTION
In the performance tests, after successfully completing it scales down the cluster nodes for the project. Rabbitmq is a statefulset so when it gets scaled back up, it tries to synchronise 3 million records back onto the RH queue. This is causing our rabbit to struggle to start up and when the performance test tries to purge the queues, it's unable to establish a connection to rabbit which causes the tests to fail.

We need to make it so that the test queues get purged before and after the tests are finished so it doesn't struggle to start up. 

https://trello.com/c/R2yABPG0/574-purge-rabbit-queues-in-performance-tests-before-and-after-finishing