### PR TITLE
Add prints to rabbit clear down

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -26,10 +26,6 @@ def before_scenario(context, scenario):
     _clear_down_all_queues()
 
 
-def after_all(_):
-    _clear_down_all_queues()
-
-
 def get_msg_count(queue_name):
     uri = f'http://{Config.RABBITMQ_HOST}:{Config.RABBITMQ_MAN_PORT}/api/queues/%2f/{queue_name}'
     response = requests.get(uri, auth=(Config.RABBITMQ_USER, Config.RABBITMQ_PASSWORD))

--- a/features/environment.py
+++ b/features/environment.py
@@ -41,9 +41,10 @@ def get_msg_count(queue_name):
 
 def _clear_down_all_queues():
     all_queues = _get_all_queues()
+    print(f'About to clear down queues: {all_queues}')
 
     for queue in all_queues:
-        # keep killing this Delayed queue, just to stop it redlivering anything in some mad race condition
+        # keep killing this Delayed queue, just to stop it redelivering anything in some mad race condition
         _clear_down_queue(Config.RABBITMQ_DELAYED_REDELIVERY_QUEUE)
         _clear_down_queue(queue)
 
@@ -58,6 +59,7 @@ def _get_all_queues():
 
 
 def _clear_down_queue(queue_name):
+    print(f'Clearing down queue: {queue_name}')
     failed_attempts = 0
 
     while True:

--- a/features/steps/print_steps.py
+++ b/features/steps/print_steps.py
@@ -24,7 +24,8 @@ def wait_for_print_files(context):
                 time_taken_metric = json.dumps({
                     'event_description': 'Time from action rule trigger to all print files produced',
                     'event_type': 'ACTION_RULE_TO_PRINT',
-                    'time_in_seconds': str(context.print_file_production_run_time.total_seconds())
+                    'time_in_seconds': str(context.print_file_production_run_time.total_seconds()),
+                    'time_taken': str(context.print_file_production_run_time)
                 })
                 print(f'{time_taken_metric}\n')
                 break

--- a/features/steps/sample_steps.py
+++ b/features/steps/sample_steps.py
@@ -56,7 +56,8 @@ def wait_for_full_sample_ingest(context):
     time_taken_metric = json.dumps({
         'event_description': 'Time to fully ingest sample into action scheduler',
         'event_type': 'SAMPLE_INGEST_TO_ACTION_CASES',
-        'time_in_seconds': str(time_taken.total_seconds())
+        'time_in_seconds': str(time_taken.total_seconds()),
+        'time_taken': str(time_taken)
     })
     print(f'{time_taken_metric}\n')
 


### PR DESCRIPTION
The API call to purge rabbit fails when the queues are too big as rabbit become unresponsive when clearing down massive queues. Some print lines to see what it has tried to clear. Also removes the clear down after all step as we'll be implementing this better as a concourse job.

Also add more readable `time_taken` field to print outs (default `str` format for a timedelta is `hh:mm:ss`).