### PR TITLE
Remove noisy queue clearing printing

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -37,7 +37,6 @@ def get_msg_count(queue_name):
 
 def _clear_down_all_queues():
     all_queues = _get_all_queues()
-    print(f'About to clear down queues: {all_queues}')
 
     for queue in all_queues:
         # keep killing this Delayed queue, just to stop it redelivering anything in some mad race condition
@@ -55,7 +54,6 @@ def _get_all_queues():
 
 
 def _clear_down_queue(queue_name):
-    print(f'Clearing down queue: {queue_name}')
     failed_attempts = 0
 
     while True:


### PR DESCRIPTION
Since these tests get run with all logging enabled these prints are actually added a lot of unnecessary noise on successful runs.