### PR TITLE
Allow different tests to be run by concourse

### DIFF
--- a/features/initial_contact.feature
+++ b/features/initial_contact.feature
@@ -1,5 +1,6 @@
 Feature: RM produces all initial contact print files within a time window
 
+  @three-hundred-and-fifty-thousand
   Scenario: Sample load through to initial contact print file production
     Given the sample file has been loaded
     And the sample has been fully ingested into action scheduler database
@@ -8,6 +9,7 @@ Feature: RM produces all initial contact print files within a time window
     And they all have the correct line count
     And they are produced within the configured time limit
 
+  @three-and-a-half-million
   Scenario: 3.5 Million Sample load through to initial contact print file production
     Given the sample file has been loaded from the bucket
     And the sample has been fully ingested into action scheduler database

--- a/pubsub_features/pubsub_performance.feature
+++ b/pubsub_features/pubsub_performance.feature
@@ -1,4 +1,5 @@
 Feature: RM produces all initial contact print files within a time window
 
+  @pubsub
   Scenario: Performance test PubSub
     Given we can receipt the cases at an acceptable rate

--- a/tasks/kubectl-run-performance-tests.yml
+++ b/tasks/kubectl-run-performance-tests.yml
@@ -28,6 +28,8 @@ run:
       gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
+      export TEST_SCENARIO=`gsutil cat gs://census-rm-performance-sample-files/target-scenario-tag.txt`
+
       # THIS IS THE NEW PUBSUB PERFORMANCE TEST FANDANGO
       kubectl scale deployment case-processor --replicas=0
 
@@ -51,7 +53,7 @@ run:
       --env=RABBITMQ_MAN_PORT=15672 \
       --env=GOOGLE_SERVICE_ACCOUNT_JSON=$(kubectl get secret pubsub-credentials -o=jsonpath="{.data['service-account-key\.json']}") \
       --env=GOOGLE_APPLICATION_CREDENTIALS="/home/performancetests/service-account-key.json" \
-      -- /bin/bash -c "sleep 2; behave pubsub_features --tags=~@local-docker --no-capture"
+      -- /bin/bash -c "sleep 2; behave pubsub_features --tags=${TEST_SCENARIO} --no-capture"
 
       kubectl scale deployment case-processor --replicas=$CASE_PROCESSOR_REPLICAS
       kubectl rollout status deploy case-processor --watch=true --timeout=200s
@@ -74,4 +76,4 @@ run:
       --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
       --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
       --env=RABBITMQ_MAN_PORT=15672 \
-      -- /bin/bash -c "sleep 2; behave features --tags=~@local-docker --no-capture"
+      -- /bin/bash -c "sleep 2; behave features --tags=${TEST_SCENARIO} --no-capture"


### PR DESCRIPTION
# Motivation and Context
30 million takes ages. 3.5 million takes 3 hours. 350k takes 40 minutes. PubSub takes a couple of minutes. We want a way to run the test we want, not have to run ALL of them.

# What has changed
Made scenarios configurable for different poipoises.

# How to test?
Fly. Fly. Fly.

# Links
Trello: https://trello.com/c/zWLwrX72