### PR TITLE
Enable sample loader info logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ lint:
 	pipenv run flake8
 
 check:
-	pipenv check
+	# TODO reinstate this once https://github.com/pypa/pipenv/issues/4188 is resolved
+	#pipenv check
 
 test: lint check performance-test
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -13,6 +13,8 @@ from utilties.rabbit_context import RabbitContext
 def before_all(_):
     logging.getLogger('pika').setLevel('ERROR')
     logging.getLogger('paramiko').setLevel('ERROR')
+    logging.getLogger('load_sample').setLevel(logging.INFO)
+    logging.getLogger('load_sample').addHandler(logging.StreamHandler())
     logging.captureWarnings(True)
 
 

--- a/tasks/kubectl-run-performance-tests.yml
+++ b/tasks/kubectl-run-performance-tests.yml
@@ -78,4 +78,4 @@ run:
       --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
       --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
       --env=RABBITMQ_MAN_PORT=15672 \
-      -- /bin/bash -c "sleep 2; behave features --tags=${TEST_SCENARIO} --no-capture"
+      -- /bin/bash -c "sleep 2; behave features --tags=${TEST_SCENARIO} --no-capture --no-logcapture"


### PR DESCRIPTION
We want to enable the sample loader info logs to see if this constant stream of log lines stops the concourse container connection from dying (or at least give us some insight into when/how it is dying). 