### PR TITLE
Add more keepalive info logging

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 structlog = "*"
 behave = "*"
 pika = "*"
-census-rm-sample-loader = {editable = true,git = "https://github.com/ONSdigital/census-rm-sample-loader",ref = "v2.0.0"}
+census-rm-sample-loader = {editable = true,git = "https://github.com/ONSdigital/census-rm-sample-loader",ref = "make-log-frequency-configurable"} # TODO replace with release version
 paramiko = "*"
 pgpy = "*"
 requests = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 structlog = "*"
 behave = "*"
 pika = "*"
-census-rm-sample-loader = {editable = true,git = "https://github.com/ONSdigital/census-rm-sample-loader",ref = "make-log-frequency-configurable"} # TODO replace with release version
+census-rm-sample-loader = {editable = true,git = "https://github.com/ONSdigital/census-rm-sample-loader",ref = "v2.1.0"}
 paramiko = "*"
 pgpy = "*"
 requests = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8b00ab28c7c834be2c874ee0ca5e7d495ed9792ebae4e024d63ef83015285fde"
+            "sha256": "f497e62df5f83452c7ca98e5197ab6009df7ecb23ea86864b526cba124fc7d3c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -57,7 +57,7 @@
         "census-rm-sample-loader": {
             "editable": true,
             "git": "https://github.com/ONSdigital/census-rm-sample-loader",
-            "ref": "3fff9f4a2cec8697afb788de743467bfd527973f"
+            "ref": "5c56af6bb1603e43837ed39ffce459693563cf92"
         },
         "certifi": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c278db310b09f08c674f80cd759f147ed2101bae43eead04324fecc8ae43fc17"
+            "sha256": "8b00ab28c7c834be2c874ee0ca5e7d495ed9792ebae4e024d63ef83015285fde"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -49,15 +49,15 @@
         },
         "cachetools": {
             "hashes": [
-                "sha256:9a52dd97a85f257f4e4127f15818e71a0c7899f121b34591fcc1173ea79a0198",
-                "sha256:b304586d357c43221856be51d73387f93e2a961598a9b6b6670664746f3b6c6c"
+                "sha256:1d057645db16ca7fe1f3bd953558897603d6f0b9c51ed9d11eb4d071ec4e2aab",
+                "sha256:de5d88f87781602201cde465d3afe837546663b168e8b39df67411b0bf10cefc"
             ],
-            "version": "==4.0.0"
+            "version": "==4.1.0"
         },
         "census-rm-sample-loader": {
             "editable": true,
             "git": "https://github.com/ONSdigital/census-rm-sample-loader",
-            "ref": "d781153683347c1303973447b6b2383d4cc85c4a"
+            "ref": "3fff9f4a2cec8697afb788de743467bfd527973f"
         },
         "certifi": {
             "hashes": [
@@ -135,17 +135,17 @@
                 "grpc"
             ],
             "hashes": [
-                "sha256:859f7392676761f2b160c6ee030c3422135ada4458f0948c5690a6a7c8d86294",
-                "sha256:92e962a087f1c4b8d1c5c88ade1c1dfd550047dcffb320c57ef6a534a20403e2"
+                "sha256:c0e430658ed6be902d7ba7095fb0a9cac810270d71bf7ac4484e76c300407aae",
+                "sha256:e4082a0b479dc2dee2f8d7b80ea8b5d0184885b773caab15ab1836277a01d689"
             ],
-            "version": "==1.16.0"
+            "version": "==1.17.0"
         },
         "google-auth": {
             "hashes": [
-                "sha256:a5ee4c40fef77ea756cf2f1c0adcf475ecb53af6700cf9c133354cdc9b267148",
-                "sha256:cab6c707e6ee20e567e348168a5c69dc6480384f777a9e5159f4299ad177dcc0"
+                "sha256:050f1713142fa57d4b34f4fd4a998210e330f6a29c84c6ce359b928cc11dc8ad",
+                "sha256:9813eaae335c45e8a1b5d274610fa961ac8aa650568d1cfb005b2c07da6bde6c"
             ],
-            "version": "==1.13.1"
+            "version": "==1.14.0"
         },
         "google-cloud-core": {
             "hashes": [

--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -5,6 +6,9 @@ from pathlib import Path
 class Config:
     PROJECT_PATH = Path(__file__).parent
     PROTOCOL = os.getenv('PROTOCOL', 'http')
+
+    LOG_LEVEL = os.getenv('LOG_LEVEL', logging.ERROR)
+    SAMPLE_LOAD_LOG_FREQUENCY = int(os.getenv('SAMPLE_LOAD_LOG_FREQUENCY', 100000))
 
     ACTION_SERVICE_HOST = os.getenv('ACTION_SERVICE_HOST', 'localhost')
     ACTION_SERVICE_PORT = os.getenv('ACTION_SERVICE_PORT', '8301')

--- a/features/environment.py
+++ b/features/environment.py
@@ -11,10 +11,9 @@ from utilties.rabbit_context import RabbitContext
 
 
 def before_all(_):
+    logging.basicConfig(level=Config.LOG_LEVEL)
     logging.getLogger('pika').setLevel('ERROR')
     logging.getLogger('paramiko').setLevel('ERROR')
-    logging.getLogger('load_sample').setLevel(logging.INFO)
-    logging.getLogger('load_sample').addHandler(logging.StreamHandler())
     logging.captureWarnings(True)
 
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -25,7 +25,7 @@ def before_scenario(context, scenario):
     _clear_down_all_queues()
 
 
-def get_msg_count(queue_name):
+def get_message_count(queue_name):
     uri = f'http://{Config.RABBITMQ_HOST}:{Config.RABBITMQ_MAN_PORT}/api/queues/%2f/{queue_name}'
     response = requests.get(uri, auth=(Config.RABBITMQ_USER, Config.RABBITMQ_PASSWORD))
     response.raise_for_status()
@@ -69,7 +69,7 @@ def _clear_down_queue(queue_name):
             print(f'Failed with {response.status_code} retry attempt {failed_attempts}')
             time.sleep(10)
 
-        if get_msg_count(queue_name) == 0:
+        if get_message_count(queue_name) == 0:
             return
 
         time.sleep(1)

--- a/features/steps/print_steps.py
+++ b/features/steps/print_steps.py
@@ -53,8 +53,8 @@ def wait_for_print_files(context, timeout):
             update_actual_line_counts(print_file_sftp_paths, sftp, context)
             if context.expected_line_counts == context.actual_line_counts:
                 logger.info('All print files found')
-                context.print_file_production_run_time = context.produced_print_file_time \
-                                                         - context.action_rule_trigger_time
+                context.print_file_production_run_time = (context.produced_print_file_time
+                                                          - context.action_rule_trigger_time)
                 time_taken_metric = json.dumps({
                     'event_description': 'Time from action rule trigger to all print files produced',
                     'event_type': 'ACTION_RULE_TO_PRINT',

--- a/features/steps/print_steps.py
+++ b/features/steps/print_steps.py
@@ -69,7 +69,7 @@ def wait_for_print_files(context, timeout):
                                f" actual_line_counts: {context.actual_line_counts}")
         sleep(int(Config.SFTP_POLLING_DELAY_SECONDS))
         attempts += 1
-        if not attempts % 200:
+        if not attempts % 300:
             logger.info('Still waiting for print files')
 
 

--- a/features/steps/sample_steps.py
+++ b/features/steps/sample_steps.py
@@ -43,7 +43,8 @@ def load_file(context, sample_file_name):
                      host=Config.RABBITMQ_HOST, port=Config.RABBITMQ_PORT,
                      vhost=Config.RABBITMQ_VHOST, exchange=Config.RABBITMQ_EXCHANGE,
                      user=Config.RABBITMQ_USER, password=Config.RABBITMQ_PASSWORD,
-                     queue_name=Config.RABBITMQ_SAMPLE_INBOUND_QUEUE)
+                     queue_name=Config.RABBITMQ_SAMPLE_INBOUND_QUEUE,
+                     sample_unit_log_frequency=Config.SAMPLE_LOAD_LOG_FREQUENCY)
 
 
 @step("the sample has been fully ingested into action scheduler database")

--- a/pubsub_features/steps/receipt_steps.py
+++ b/pubsub_features/steps/receipt_steps.py
@@ -7,7 +7,7 @@ from behave import step
 from google.cloud import pubsub_v1
 
 from config import Config
-from features.environment import get_msg_count, _clear_down_queue
+from features.environment import get_message_count, _clear_down_queue
 
 
 @step("we can receipt the cases at an acceptable rate")
@@ -53,7 +53,7 @@ def publish_message(publisher, json_message, topic_path):
 
 def wait_for_queue_to_reach_target(queue_name, target):
     loop_start_time = datetime.utcnow()
-    while get_msg_count(queue_name) < target:
+    while get_message_count(queue_name) < target:
         time.sleep(1)
         if (datetime.utcnow() - loop_start_time).total_seconds() > 3600:
             assert "Pubsub messages not published within time limit"

--- a/tasks/kubectl-run-performance-tests.yml
+++ b/tasks/kubectl-run-performance-tests.yml
@@ -78,4 +78,5 @@ run:
       --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
       --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
       --env=RABBITMQ_MAN_PORT=15672 \
+      --env=LOG_LEVEL=INFO \
       -- /bin/bash -c "sleep 2; behave features --tags=${TEST_SCENARIO} --no-capture --no-logcapture"

--- a/utilties/rabbit_helper.py
+++ b/utilties/rabbit_helper.py
@@ -17,7 +17,7 @@ def wait_for_queue_to_be_drained(queue_name):
     while get_msg_count(queue_name) != 0:
         time.sleep(1)
         attempts += 1
-        if not attempts % 200:
+        if not attempts % 300:
             logger.info(f"Still waiting for queue '{queue_name}' to be drained")
     logger.info(f"Queue '{queue_name}' has been drained")
 

--- a/utilties/rabbit_helper.py
+++ b/utilties/rabbit_helper.py
@@ -5,7 +5,7 @@ import time
 
 from structlog import wrap_logger
 
-from features.environment import get_msg_count
+from features.environment import get_message_count
 from utilties.rabbit_context import RabbitContext
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -14,16 +14,19 @@ logger = wrap_logger(logging.getLogger(__name__))
 def wait_for_queue_to_be_drained(queue_name):
     attempts = 0
     logger.info(f"Waiting for queue '{queue_name}' to be drained")
-    while get_msg_count(queue_name) != 0:
+    while True:
+        message_count = get_message_count(queue_name)
+        if message_count == 0:
+            logger.info(f"Queue '{queue_name}' has been drained")
+            return
         time.sleep(1)
         attempts += 1
         if not attempts % 300:
-            logger.info(f"Still waiting for queue '{queue_name}' to be drained")
-    logger.info(f"Queue '{queue_name}' has been drained")
+            logger.info(f"Waiting for queue '{queue_name}' to be drained, {message_count} messages remain")
 
 
 def wait_for_messages_to_be_queued(queue_name, message_count):
-    while get_msg_count(queue_name) < message_count:
+    while get_message_count(queue_name) < message_count:
         time.sleep(1)
 
 

--- a/utilties/rabbit_helper.py
+++ b/utilties/rabbit_helper.py
@@ -3,27 +3,28 @@ import json
 import logging
 import time
 
+from structlog import wrap_logger
+
 from features.environment import get_msg_count
 from utilties.rabbit_context import RabbitContext
-
-from structlog import wrap_logger
 
 logger = wrap_logger(logging.getLogger(__name__))
 
 
 def wait_for_queue_to_be_drained(queue_name):
-    while True:
-        if get_msg_count(queue_name) == 0:
-            return
-
+    attempts = 0
+    logger.info(f"Waiting for queue '{queue_name}' to be drained")
+    while get_msg_count(queue_name) != 0:
         time.sleep(1)
+        attempts += 1
+        if not attempts % 200:
+            logger.info(f"Still waiting for queue '{queue_name}' to be drained")
+    logger.info(f"Queue '{queue_name}' has been drained")
 
 
 def wait_for_messages_to_be_queued(queue_name, message_count):
     while get_msg_count(queue_name) < message_count:
         time.sleep(1)
-
-    return
 
 
 def start_listening_to_rabbit_queue(queue, on_message_callback, timeout=30):


### PR DESCRIPTION
## Why
Adding the sample load logging seemed to keep the connection alive in concourse, next step is to add more in (and refine it slightly with a configurable level).

## What
* Use configurable sample load log frequency
* Use configurable log level
* Add info logging in queue drain wait
* Add info logging in print file wait

## Wherefore
https://trello.com/c/xNdUzmdK/801-why-does-concourse-stop-outputting-performance-test-logs-during-30-million-test-1-day
https://github.com/ONSdigital/census-rm-sample-loader/pull/30
