### PR TITLE
Fix logging and sleep indent

### DIFF
--- a/features/initial_contact.feature
+++ b/features/initial_contact.feature
@@ -21,5 +21,5 @@ Feature: RM produces all initial contact print files within a time window
     Given the sample file "30_million_household_sample.csv" has been loaded from the bucket
     And the sample has been fully ingested into action scheduler database
     When all initial contact action rules are scheduled for now
-    Then all the initial contact print files are produced on the SFTP containing the correct total number of cases within 24 hours
-    And they are produced within the time limit 1440 minutes
+    Then all the initial contact print files are produced on the SFTP containing the correct total number of cases within 12 hours
+    And they are produced within the time limit 720 minutes

--- a/features/steps/print_steps.py
+++ b/features/steps/print_steps.py
@@ -67,10 +67,10 @@ def wait_for_print_files(context, timeout):
             if datetime.utcnow() - timeout_start >= timedelta(hours=int(timeout)):
                 assert False, (f"Timed out waiting for print files after {timeout} hours,"
                                f" actual_line_counts: {context.actual_line_counts}")
-        sleep(int(Config.SFTP_POLLING_DELAY_SECONDS))
-        attempts += 1
-        if not attempts % 300:
-            logger.info('Still waiting for print files')
+            sleep(int(Config.SFTP_POLLING_DELAY_SECONDS))
+            attempts += 1
+            if not attempts % 300:
+                logger.info('Still waiting for print files', current_line_counts=context.actual_line_counts)
 
 
 def fetch_all_print_files_paths(sftp, context):


### PR DESCRIPTION
The log and sleep lines were not properly indented and were outside the loop
Also the print files for 30 million should take well under 12 hours so I've reduced the timeout in the feature.

https://trello.com/c/xNdUzmdK/801-why-does-concourse-stop-outputting-performance-test-logs-during-30-million-test-1-day