### PR TITLE
Restore pipenv package vuln check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ lint:
 	pipenv run flake8
 
 check:
-	# TODO reinstate this once https://github.com/pypa/pipenv/issues/4188 is resolved
-	#pipenv check
+	PIPENV_PYUP_API_KEY="" pipenv check
 
 test: lint check performance-test
 


### PR DESCRIPTION
# Motivation and Context
Pipenv package vuln check was failing with an API key error.

# What has changed
Implemented workaround.

# How to test?
Run `make check`.

# Links
Trello: https://trello.com/c/AcwAmLZ4