### PR TITLE
Use dedicated SA for performance tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -45,6 +45,3 @@ class Config:
     CASE_RECEIPT_QUEUE_NAME = "Case.Responses"
     PUBSUB_PROJECT = os.getenv('PUBSUB_PROJECT', "census-rm-performance")
     PUBSUB_TOPIC = os.getenv('PUBSUB_TOPIC', "receipting-topic-performance")
-
-    GOOGLE_APPLICATION_CREDENTIALS = os.getenv('GOOGLE_APPLICATION_CREDENTIALS')
-    GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv('GOOGLE_SERVICE_ACCOUNT_JSON')

--- a/pubsub_features/environment.py
+++ b/pubsub_features/environment.py
@@ -1,21 +1,3 @@
-import base64
-import json
-
-from config import Config
-
-
-def before_all(_context):
-    _setup_google_auth()
-
-
 def before_scenario(context, scenario):
     assert len(scenario.effective_tags) == 1, 'Unexpected scenario tags'
     context.scenario_tag = scenario.effective_tags[0]
-
-
-def _setup_google_auth():
-    if Config.GOOGLE_SERVICE_ACCOUNT_JSON and Config.GOOGLE_APPLICATION_CREDENTIALS:
-        sa_json = json.loads(base64.b64decode(Config.GOOGLE_SERVICE_ACCOUNT_JSON))
-        with open(Config.GOOGLE_APPLICATION_CREDENTIALS, 'w') as credentials_file:
-            json.dump(sa_json, credentials_file)
-        print(f'Created GOOGLE_APPLICATION_CREDENTIALS: {Config.GOOGLE_APPLICATION_CREDENTIALS}')

--- a/run_gke.sh
+++ b/run_gke.sh
@@ -41,7 +41,7 @@ echo "Running Census RM Performance Tests [`kubectl config current-context`]..."
 
 
 kubectl run performance-tests -it --command --rm --quiet --generator=run-pod/v1 \
-    --image=$IMAGE --restart=Never \
+    --image=$IMAGE --restart=Never --serviceaccount=performance-tests \
     $(while read env; do echo --env=${env}; done < kubernetes.env) \
     --env=SFTP_HOST=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.host}" | base64 --decode) \
     --env=SFTP_USERNAME=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode) \

--- a/tasks/kubectl-run-performance-tests.yml
+++ b/tasks/kubectl-run-performance-tests.yml
@@ -42,6 +42,7 @@ run:
         --generator=run-pod/v1 \
         --image=${PERFORMANCE_TESTS_IMAGE} \
         --restart=Never \
+        --serviceaccount=performance-tests \
         $(while read env; do echo --env=${env}; done < performance-tests-repo/kubernetes.env) \
         --env=SFTP_HOST=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.host}" | base64 --decode) \
         --env=SFTP_USERNAME=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode) \
@@ -52,8 +53,6 @@ run:
         --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
         --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
         --env=RABBITMQ_MAN_PORT=15672 \
-        --env=GOOGLE_SERVICE_ACCOUNT_JSON=$(kubectl get secret pubsub-credentials -o=jsonpath="{.data['service-account-key\.json']}") \
-        --env=GOOGLE_APPLICATION_CREDENTIALS="/home/performancetests/service-account-key.json" \
         -- /bin/bash -c "sleep 2; behave pubsub_features --tags=${TEST_SCENARIO} --no-capture"
 
         kubectl scale deployment case-processor --replicas=$CASE_PROCESSOR_REPLICAS
@@ -68,6 +67,7 @@ run:
       --generator=run-pod/v1 \
       --image=${PERFORMANCE_TESTS_IMAGE} \
       --restart=Never \
+      --serviceaccount=performance-tests \
       $(while read env; do echo --env=${env}; done < performance-tests-repo/kubernetes.env) \
       --env=SFTP_HOST=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.host}" | base64 --decode) \
       --env=SFTP_USERNAME=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode) \


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can start to move our RM apps to use Workload Identity in our GCP clusters. Each k8s service that interacts with GCP can now use its own service account. This PR adds a service account to the performance tests 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Added SA to run command
* Removed env vars

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
See Terraform PR

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://github.com/ONSdigital/census-rm-terraform/pull/168
https://github.com/ONSdigital/census-rm-kubernetes/pull/245
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/253

[Trello](https://trello.com/c/Z5kmTtll/970-workload-identity-update-pub-sub-printfilesvc-acceptance-and-performance-tests-13)