### PR TITLE
Revert workload identity

### DIFF
--- a/config.py
+++ b/config.py
@@ -45,3 +45,6 @@ class Config:
     CASE_RECEIPT_QUEUE_NAME = "Case.Responses"
     PUBSUB_PROJECT = os.getenv('PUBSUB_PROJECT', "census-rm-performance")
     PUBSUB_TOPIC = os.getenv('PUBSUB_TOPIC', "receipting-topic-performance")
+
+    GOOGLE_APPLICATION_CREDENTIALS = os.getenv('GOOGLE_APPLICATION_CREDENTIALS')
+    GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv('GOOGLE_SERVICE_ACCOUNT_JSON')

--- a/pubsub_features/environment.py
+++ b/pubsub_features/environment.py
@@ -1,3 +1,21 @@
+import base64
+import json
+
+from config import Config
+
+
+def before_all(_context):
+    _setup_google_auth()
+
+
 def before_scenario(context, scenario):
     assert len(scenario.effective_tags) == 1, 'Unexpected scenario tags'
     context.scenario_tag = scenario.effective_tags[0]
+
+
+def _setup_google_auth():
+    if Config.GOOGLE_SERVICE_ACCOUNT_JSON and Config.GOOGLE_APPLICATION_CREDENTIALS:
+        sa_json = json.loads(base64.b64decode(Config.GOOGLE_SERVICE_ACCOUNT_JSON))
+        with open(Config.GOOGLE_APPLICATION_CREDENTIALS, 'w') as credentials_file:
+            json.dump(sa_json, credentials_file)
+        print(f'Created GOOGLE_APPLICATION_CREDENTIALS: {Config.GOOGLE_APPLICATION_CREDENTIALS}')

--- a/run_gke.sh
+++ b/run_gke.sh
@@ -41,7 +41,7 @@ echo "Running Census RM Performance Tests [`kubectl config current-context`]..."
 
 
 kubectl run performance-tests -it --command --rm --quiet --generator=run-pod/v1 \
-    --image=$IMAGE --restart=Never --serviceaccount=performance-tests \
+    --image=$IMAGE --restart=Never \
     $(while read env; do echo --env=${env}; done < kubernetes.env) \
     --env=SFTP_HOST=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.host}" | base64 --decode) \
     --env=SFTP_USERNAME=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode) \

--- a/tasks/kubectl-run-performance-tests.yml
+++ b/tasks/kubectl-run-performance-tests.yml
@@ -42,7 +42,6 @@ run:
         --generator=run-pod/v1 \
         --image=${PERFORMANCE_TESTS_IMAGE} \
         --restart=Never \
-        --serviceaccount=performance-tests \
         $(while read env; do echo --env=${env}; done < performance-tests-repo/kubernetes.env) \
         --env=SFTP_HOST=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.host}" | base64 --decode) \
         --env=SFTP_USERNAME=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode) \
@@ -53,6 +52,8 @@ run:
         --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
         --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
         --env=RABBITMQ_MAN_PORT=15672 \
+        --env=GOOGLE_SERVICE_ACCOUNT_JSON=$(kubectl get secret pubsub-credentials -o=jsonpath="{.data['service-account-key\.json']}") \
+        --env=GOOGLE_APPLICATION_CREDENTIALS="/home/performancetests/service-account-key.json" \
         -- /bin/bash -c "sleep 2; behave pubsub_features --tags=${TEST_SCENARIO} --no-capture"
 
         kubectl scale deployment case-processor --replicas=$CASE_PROCESSOR_REPLICAS
@@ -67,7 +68,6 @@ run:
       --generator=run-pod/v1 \
       --image=${PERFORMANCE_TESTS_IMAGE} \
       --restart=Never \
-      --serviceaccount=performance-tests \
       $(while read env; do echo --env=${env}; done < performance-tests-repo/kubernetes.env) \
       --env=SFTP_HOST=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.host}" | base64 --decode) \
       --env=SFTP_USERNAME=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode) \


### PR DESCRIPTION
After enabling Workload Identity in our cluster, we're unable to connect to the read replica SQL instance with our census-rm-toolbox. To buy us some time to investigate, we can revert these changes for now.

Trello: https://trello.com/c/Z5kmTtll/970-workload-identity-update-pub-sub-printfilesvc-acceptance-and-performance-tests-13